### PR TITLE
Refactoring code complexity in src/middleware/render.js

### DIFF
--- a/src/groups/ownership.js
+++ b/src/groups/ownership.js
@@ -7,7 +7,7 @@ module.exports = function (Groups) {
 	Groups.ownership = {};
 
 	Groups.ownership.isOwner = async function (uid, groupName) {
-		if (!(parseInt(uid, 10) > 0)) {
+		if (!(parseInt(uid, 10) <= 0)) {
 			return false;
 		}
 		return await db.isSetMember(`group:${groupName}:owners`, uid);

--- a/src/groups/ownership.js
+++ b/src/groups/ownership.js
@@ -7,7 +7,7 @@ module.exports = function (Groups) {
 	Groups.ownership = {};
 
 	Groups.ownership.isOwner = async function (uid, groupName) {
-		if (!(parseInt(uid, 10) <= 0)) {
+		if (!(parseInt(uid, 10) > 0)) {
 			return false;
 		}
 		return await db.isSetMember(`group:${groupName}:owners`, uid);

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -152,151 +152,9 @@ module.exports = function (middleware) {
 		return null;
 	}
 
-	// function initializeTemplateValues(res, options, registrationType) {
-	// 	return {
-	// 		title: meta.config.title || '',
-	// 		'title:url': meta.config['title:url'] || '',
-	// 		description: meta.config.description || '',
-	// 		'cache-buster': meta.config['cache-buster'] || '',
-	// 		'brand:logo': meta.config['brand:logo'] || '',
-	// 		'brand:logo:url': meta.config['brand:logo:url'] || '',
-	// 		'brand:logo:alt': meta.config['brand:logo:alt'] || '',
-	// 		'brand:logo:display': meta.config['brand:logo'] ? '' : 'hide',
-	// 		allowRegistration: registrationType === 'normal',
-	// 		searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
-	// 		postQueueEnabled: !!meta.config.postQueue,
-	// 		registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' 
-	// 			|| (meta.config.registrationType === 'invite-only' || meta.config.registrationType === 'admin-invite-only'),
-	// 		config: res.locals.config,
-	// 		relative_path,
-	// 		bodyClass: options.bodyClass,
-	// 		widgets: options.widgets,
-	// 		configJSON: jsesc(JSON.stringify(res.locals.config), { isScriptContext: true }),
-	// 		useCustomCSS: meta.config.useCustomCSS && meta.config.customCSS,
-	// 		customCSS: meta.config.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '',
-	// 		useCustomHTML: meta.config.useCustomHTML,
-	// 		customHTML: meta.config.useCustomHTML ? meta.config.customHTML : '',
-	// 		maintenanceHeader: meta.config.maintenanceMode && !results.isAdmin,
-	// 		defaultLang: meta.config.defaultLang || 'en-GB',
-	// 		userLang: res.locals.config.userLang,
-	// 	};
-	// }
-
-	// async function loadClientHeaderFooterData(req, res, options) {
-	// 	const registrationType = meta.config.registrationType || 'normal';
-	// 	res.locals.config = res.locals.config || {};
-
-
-	// 	const templateValues = initializeTemplateValues(res, options, registrationType);
-
-	// 	templateValues.configJSON = jsesc(JSON.stringify(res.locals.config), { isScriptContext: true });
-
-	// 	const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
-	// 	const results = await utils.promiseParallel({
-	// 		isAdmin: user.isAdministrator(req.uid),
-	// 		isGlobalMod: user.isGlobalModerator(req.uid),
-	// 		isModerator: user.isModeratorOfAnyCategory(req.uid),
-	// 		privileges: privileges.global.get(req.uid),
-	// 		blocks: user.blocks.list(req.uid),
-	// 		user: user.getUserData(req.uid),
-	// 		isEmailConfirmSent: req.uid <= 0 ? false : await user.email.isValidationPending(req.uid),
-	// 		languageDirection: translator.translate('[[language:dir]]', res.locals.config.userLang),
-	// 		timeagoCode: languages.userTimeagoCode(res.locals.config.userLang),
-	// 		browserTitle: translator.translate(controllersHelpers.buildTitle(title)),
-	// 		navigation: navigation.get(req.uid),
-	// 		roomIds: req.uid > 0 ? db.getSortedSetRevRange(`uid:${req.uid}:chat:rooms`, 0, 0) : [],
-	// 	});
-
-	// 	const unreadData = {
-	// 		'': {},
-	// 		new: {},
-	// 		watched: {},
-	// 		unreplied: {},
-	// 	};
-
-	// 	results.user.unreadData = unreadData;
-	// 	results.user.isAdmin = results.isAdmin;
-	// 	results.user.isGlobalMod = results.isGlobalMod;
-	// 	results.user.isMod = !!results.isModerator;
-	// 	results.user.privileges = results.privileges;
-	// 	results.user.blocks = results.blocks;
-	// 	results.user.timeagoCode = results.timeagoCode;
-	// 	results.user[results.user.status] = true;
-	// 	results.user.lastRoomId = results.roomIds.length ? results.roomIds[0] : null;
-
-	// 	results.user.email = String(results.user.email);
-	// 	results.user['email:confirmed'] = results.user['email:confirmed'] === 1;
-	// 	results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
-
-	// 	templateValues.bootswatchSkin = res.locals.config.bootswatchSkin || '';
-	// 	templateValues.browserTitle = results.browserTitle;
-	// 	({
-	// 		navigation: templateValues.navigation,
-	// 		unreadCount: templateValues.unreadCount,
-	// 	} = await appendUnreadCounts({
-	// 		uid: req.uid,
-	// 		query: req.query,
-	// 		navigation: results.navigation,
-	// 		unreadData,
-	// 	}));
-
-	// 	templateValues.isAdmin = results.user.isAdmin;
-	// 	templateValues.isGlobalMod = results.user.isGlobalMod;
-	// 	templateValues.showModMenu = results.user.isAdmin || results.user.isGlobalMod || results.user.isMod;
-	// 	templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged']) && meta.config.disableChat !== 1;
-	// 	templateValues.user = results.user;
-	// 	templateValues.userJSON = jsesc(JSON.stringify(results.user), { isScriptContext: true });
-	// 	templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS;
-	// 	templateValues.customCSS = templateValues.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '';
-	// 	templateValues.useCustomHTML = meta.config.useCustomHTML;
-	// 	templateValues.customHTML = templateValues.useCustomHTML ? meta.config.customHTML : '';
-	// 	templateValues.maintenanceHeader = meta.config.maintenanceMode && !results.isAdmin;
-	// 	templateValues.defaultLang = meta.config.defaultLang || 'en-GB';
-	// 	templateValues.userLang = res.locals.config.userLang;
-	// 	templateValues.languageDirection = results.languageDirection;
-	// 	if (req.query.noScriptMessage) {
-	// 		templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
-	// 	}
-
-	// 	templateValues.template = { name: res.locals.template };
-	// 	templateValues.template[res.locals.template] = true;
-
-	// 	if (options.hasOwnProperty('_header')) {
-	// 		templateValues.metaTags = options._header.tags.meta;
-	// 		templateValues.linkTags = options._header.tags.link;
-	// 	}
-
-	// 	if (req.route && req.route.path === '/') {
-	// 		modifyTitle(templateValues);
-	// 	}
-	// 	return templateValues;
-	// }
-	
-	async function loadClientHeaderFooterData(req, res, options) {
+	async function initializeTemplate (options){
 		const registrationType = meta.config.registrationType || 'normal';
 		res.locals.config = res.locals.config || {};
-		const templateValues = initializeTemplateValues(req, res, options, registrationType);
-		
-		const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
-		const results = await gatherUserData(req, title);
-		
-		updateUserData(results);
-		updateTemplateValues(templateValues, results, req, res, options);
-	
-		if (req.query.noScriptMessage) {
-			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
-		}
-		templateValues.template = { name: res.locals.template };
-		templateValues.template[res.locals.template] = true;
-	
-		if (req.route && req.route.path === '/') {
-			modifyTitle(templateValues);
-		}
-		
-		return templateValues;
-	}
-	
-	function initializeTemplateValues(req, res, options, registrationType) {
 		return {
 			title: meta.config.title || '',
 			'title:url': meta.config['title:url'] || '',
@@ -309,25 +167,21 @@ module.exports = function (middleware) {
 			allowRegistration: registrationType === 'normal',
 			searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
 			postQueueEnabled: !!meta.config.postQueue,
-			registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' 
-				|| (meta.config.registrationType === 'invite-only' || meta.config.registrationType === 'admin-invite-only'),
+			registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' || (meta.config.registrationType === 'invite-only' || meta.config.registrationType === 'admin-invite-only'),
 			config: res.locals.config,
 			relative_path,
 			bodyClass: options.bodyClass,
 			widgets: options.widgets,
-			configJSON: jsesc(JSON.stringify(res.locals.config), { isScriptContext: true }),
-			useCustomCSS: meta.config.useCustomCSS && meta.config.customCSS,
-			customCSS: meta.config.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '',
-			useCustomHTML: meta.config.useCustomHTML,
-			customHTML: meta.config.useCustomHTML ? meta.config.customHTML : '',
-			maintenanceHeader: meta.config.maintenanceMode && !results.isAdmin,
-			defaultLang: meta.config.defaultLang || 'en-GB',
-			userLang: res.locals.config.userLang,
 		};
+
 	}
-	
-	async function gatherUserData(req, title) {
-		return await utils.promiseParallel({
+	async function loadClientHeaderFooterData(req, res, options) {
+		const templateValues = initializeTemplate(options);
+
+		templateValues.configJSON = jsesc(JSON.stringify(res.locals.config), { isScriptContext: true });
+
+		const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
+		const results = await utils.promiseParallel({
 			isAdmin: user.isAdministrator(req.uid),
 			isGlobalMod: user.isGlobalModerator(req.uid),
 			isModerator: user.isModeratorOfAnyCategory(req.uid),
@@ -341,15 +195,14 @@ module.exports = function (middleware) {
 			navigation: navigation.get(req.uid),
 			roomIds: req.uid > 0 ? db.getSortedSetRevRange(`uid:${req.uid}:chat:rooms`, 0, 0) : [],
 		});
-	}
-	
-	function updateUserData(results) {
+
 		const unreadData = {
 			'': {},
 			new: {},
 			watched: {},
 			unreplied: {},
 		};
+
 		results.user.unreadData = unreadData;
 		results.user.isAdmin = results.isAdmin;
 		results.user.isGlobalMod = results.isGlobalMod;
@@ -359,14 +212,13 @@ module.exports = function (middleware) {
 		results.user.timeagoCode = results.timeagoCode;
 		results.user[results.user.status] = true;
 		results.user.lastRoomId = results.roomIds.length ? results.roomIds[0] : null;
+
 		results.user.email = String(results.user.email);
 		results.user['email:confirmed'] = results.user['email:confirmed'] === 1;
 		results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
-	}
-	
-	async function updateTemplateValues(templateValues, results, req, res, options) {
+
+		templateValues.bootswatchSkin = res.locals.config.bootswatchSkin || '';
 		templateValues.browserTitle = results.browserTitle;
-	
 		({
 			navigation: templateValues.navigation,
 			unreadCount: templateValues.unreadCount,
@@ -374,26 +226,40 @@ module.exports = function (middleware) {
 			uid: req.uid,
 			query: req.query,
 			navigation: results.navigation,
-			unreadData: results.user.unreadData,
+			unreadData,
 		}));
-	
 		templateValues.isAdmin = results.user.isAdmin;
 		templateValues.isGlobalMod = results.user.isGlobalMod;
 		templateValues.showModMenu = results.user.isAdmin || results.user.isGlobalMod || results.user.isMod;
-		templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged'])
-			&& meta.config.disableChat !== 1;
+		templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged']) && meta.config.disableChat !== 1;
 		templateValues.user = results.user;
 		templateValues.userJSON = jsesc(JSON.stringify(results.user), { isScriptContext: true });
+		templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS;
+		templateValues.customCSS = templateValues.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '';
+		templateValues.useCustomHTML = meta.config.useCustomHTML;
+		templateValues.customHTML = templateValues.useCustomHTML ? meta.config.customHTML : '';
 		templateValues.maintenanceHeader = meta.config.maintenanceMode && !results.isAdmin;
 		templateValues.defaultLang = meta.config.defaultLang || 'en-GB';
 		templateValues.userLang = res.locals.config.userLang;
 		templateValues.languageDirection = results.languageDirection;
-		
+		if (req.query.noScriptMessage) {
+			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
+		}
+
+		templateValues.template = { name: res.locals.template };
+		templateValues.template[res.locals.template] = true;
+
 		if (options.hasOwnProperty('_header')) {
 			templateValues.metaTags = options._header.tags.meta;
 			templateValues.linkTags = options._header.tags.link;
 		}
+
+		if (req.route && req.route.path === '/') {
+			modifyTitle(templateValues);
+		}
+		return templateValues;
 	}
+	
 	async function loadAdminHeaderFooterData(req, res, options) {
 		const custom_header = {
 			plugins: [],

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -152,7 +152,151 @@ module.exports = function (middleware) {
 		return null;
 	}
 
-	function initializeTemplateValues(res, options, registrationType) {
+	// function initializeTemplateValues(res, options, registrationType) {
+	// 	return {
+	// 		title: meta.config.title || '',
+	// 		'title:url': meta.config['title:url'] || '',
+	// 		description: meta.config.description || '',
+	// 		'cache-buster': meta.config['cache-buster'] || '',
+	// 		'brand:logo': meta.config['brand:logo'] || '',
+	// 		'brand:logo:url': meta.config['brand:logo:url'] || '',
+	// 		'brand:logo:alt': meta.config['brand:logo:alt'] || '',
+	// 		'brand:logo:display': meta.config['brand:logo'] ? '' : 'hide',
+	// 		allowRegistration: registrationType === 'normal',
+	// 		searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
+	// 		postQueueEnabled: !!meta.config.postQueue,
+	// 		registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' 
+	// 			|| (meta.config.registrationType === 'invite-only' || meta.config.registrationType === 'admin-invite-only'),
+	// 		config: res.locals.config,
+	// 		relative_path,
+	// 		bodyClass: options.bodyClass,
+	// 		widgets: options.widgets,
+	// 		configJSON: jsesc(JSON.stringify(res.locals.config), { isScriptContext: true }),
+	// 		useCustomCSS: meta.config.useCustomCSS && meta.config.customCSS,
+	// 		customCSS: meta.config.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '',
+	// 		useCustomHTML: meta.config.useCustomHTML,
+	// 		customHTML: meta.config.useCustomHTML ? meta.config.customHTML : '',
+	// 		maintenanceHeader: meta.config.maintenanceMode && !results.isAdmin,
+	// 		defaultLang: meta.config.defaultLang || 'en-GB',
+	// 		userLang: res.locals.config.userLang,
+	// 	};
+	// }
+
+	// async function loadClientHeaderFooterData(req, res, options) {
+	// 	const registrationType = meta.config.registrationType || 'normal';
+	// 	res.locals.config = res.locals.config || {};
+
+
+	// 	const templateValues = initializeTemplateValues(res, options, registrationType);
+
+	// 	templateValues.configJSON = jsesc(JSON.stringify(res.locals.config), { isScriptContext: true });
+
+	// 	const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
+	// 	const results = await utils.promiseParallel({
+	// 		isAdmin: user.isAdministrator(req.uid),
+	// 		isGlobalMod: user.isGlobalModerator(req.uid),
+	// 		isModerator: user.isModeratorOfAnyCategory(req.uid),
+	// 		privileges: privileges.global.get(req.uid),
+	// 		blocks: user.blocks.list(req.uid),
+	// 		user: user.getUserData(req.uid),
+	// 		isEmailConfirmSent: req.uid <= 0 ? false : await user.email.isValidationPending(req.uid),
+	// 		languageDirection: translator.translate('[[language:dir]]', res.locals.config.userLang),
+	// 		timeagoCode: languages.userTimeagoCode(res.locals.config.userLang),
+	// 		browserTitle: translator.translate(controllersHelpers.buildTitle(title)),
+	// 		navigation: navigation.get(req.uid),
+	// 		roomIds: req.uid > 0 ? db.getSortedSetRevRange(`uid:${req.uid}:chat:rooms`, 0, 0) : [],
+	// 	});
+
+	// 	const unreadData = {
+	// 		'': {},
+	// 		new: {},
+	// 		watched: {},
+	// 		unreplied: {},
+	// 	};
+
+	// 	results.user.unreadData = unreadData;
+	// 	results.user.isAdmin = results.isAdmin;
+	// 	results.user.isGlobalMod = results.isGlobalMod;
+	// 	results.user.isMod = !!results.isModerator;
+	// 	results.user.privileges = results.privileges;
+	// 	results.user.blocks = results.blocks;
+	// 	results.user.timeagoCode = results.timeagoCode;
+	// 	results.user[results.user.status] = true;
+	// 	results.user.lastRoomId = results.roomIds.length ? results.roomIds[0] : null;
+
+	// 	results.user.email = String(results.user.email);
+	// 	results.user['email:confirmed'] = results.user['email:confirmed'] === 1;
+	// 	results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
+
+	// 	templateValues.bootswatchSkin = res.locals.config.bootswatchSkin || '';
+	// 	templateValues.browserTitle = results.browserTitle;
+	// 	({
+	// 		navigation: templateValues.navigation,
+	// 		unreadCount: templateValues.unreadCount,
+	// 	} = await appendUnreadCounts({
+	// 		uid: req.uid,
+	// 		query: req.query,
+	// 		navigation: results.navigation,
+	// 		unreadData,
+	// 	}));
+
+	// 	templateValues.isAdmin = results.user.isAdmin;
+	// 	templateValues.isGlobalMod = results.user.isGlobalMod;
+	// 	templateValues.showModMenu = results.user.isAdmin || results.user.isGlobalMod || results.user.isMod;
+	// 	templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged']) && meta.config.disableChat !== 1;
+	// 	templateValues.user = results.user;
+	// 	templateValues.userJSON = jsesc(JSON.stringify(results.user), { isScriptContext: true });
+	// 	templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS;
+	// 	templateValues.customCSS = templateValues.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '';
+	// 	templateValues.useCustomHTML = meta.config.useCustomHTML;
+	// 	templateValues.customHTML = templateValues.useCustomHTML ? meta.config.customHTML : '';
+	// 	templateValues.maintenanceHeader = meta.config.maintenanceMode && !results.isAdmin;
+	// 	templateValues.defaultLang = meta.config.defaultLang || 'en-GB';
+	// 	templateValues.userLang = res.locals.config.userLang;
+	// 	templateValues.languageDirection = results.languageDirection;
+	// 	if (req.query.noScriptMessage) {
+	// 		templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
+	// 	}
+
+	// 	templateValues.template = { name: res.locals.template };
+	// 	templateValues.template[res.locals.template] = true;
+
+	// 	if (options.hasOwnProperty('_header')) {
+	// 		templateValues.metaTags = options._header.tags.meta;
+	// 		templateValues.linkTags = options._header.tags.link;
+	// 	}
+
+	// 	if (req.route && req.route.path === '/') {
+	// 		modifyTitle(templateValues);
+	// 	}
+	// 	return templateValues;
+	// }
+	
+	async function loadClientHeaderFooterData(req, res, options) {
+		const registrationType = meta.config.registrationType || 'normal';
+		res.locals.config = res.locals.config || {};
+		const templateValues = initializeTemplateValues(req, res, options, registrationType);
+		
+		const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
+		const results = await gatherUserData(req, title);
+		
+		updateUserData(results);
+		updateTemplateValues(templateValues, results, req, res, options);
+	
+		if (req.query.noScriptMessage) {
+			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
+		}
+		templateValues.template = { name: res.locals.template };
+		templateValues.template[res.locals.template] = true;
+	
+		if (req.route && req.route.path === '/') {
+			modifyTitle(templateValues);
+		}
+		
+		return templateValues;
+	}
+	
+	function initializeTemplateValues(req, res, options, registrationType) {
 		return {
 			title: meta.config.title || '',
 			'title:url': meta.config['title:url'] || '',
@@ -181,18 +325,9 @@ module.exports = function (middleware) {
 			userLang: res.locals.config.userLang,
 		};
 	}
-
-	async function loadClientHeaderFooterData(req, res, options) {
-		const registrationType = meta.config.registrationType || 'normal';
-		res.locals.config = res.locals.config || {};
-
-
-		const templateValues = initializeTemplateValues(res, options, registrationType);
-
-		templateValues.configJSON = jsesc(JSON.stringify(res.locals.config), { isScriptContext: true });
-
-		const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
-		const results = await utils.promiseParallel({
+	
+	async function gatherUserData(req, title) {
+		return await utils.promiseParallel({
 			isAdmin: user.isAdministrator(req.uid),
 			isGlobalMod: user.isGlobalModerator(req.uid),
 			isModerator: user.isModeratorOfAnyCategory(req.uid),
@@ -206,14 +341,15 @@ module.exports = function (middleware) {
 			navigation: navigation.get(req.uid),
 			roomIds: req.uid > 0 ? db.getSortedSetRevRange(`uid:${req.uid}:chat:rooms`, 0, 0) : [],
 		});
-
+	}
+	
+	function updateUserData(results) {
 		const unreadData = {
 			'': {},
 			new: {},
 			watched: {},
 			unreplied: {},
 		};
-
 		results.user.unreadData = unreadData;
 		results.user.isAdmin = results.isAdmin;
 		results.user.isGlobalMod = results.isGlobalMod;
@@ -223,13 +359,14 @@ module.exports = function (middleware) {
 		results.user.timeagoCode = results.timeagoCode;
 		results.user[results.user.status] = true;
 		results.user.lastRoomId = results.roomIds.length ? results.roomIds[0] : null;
-
 		results.user.email = String(results.user.email);
 		results.user['email:confirmed'] = results.user['email:confirmed'] === 1;
 		results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
-
-		templateValues.bootswatchSkin = res.locals.config.bootswatchSkin || '';
+	}
+	
+	async function updateTemplateValues(templateValues, results, req, res, options) {
 		templateValues.browserTitle = results.browserTitle;
+	
 		({
 			navigation: templateValues.navigation,
 			unreadCount: templateValues.unreadCount,
@@ -237,41 +374,26 @@ module.exports = function (middleware) {
 			uid: req.uid,
 			query: req.query,
 			navigation: results.navigation,
-			unreadData,
+			unreadData: results.user.unreadData,
 		}));
-
+	
 		templateValues.isAdmin = results.user.isAdmin;
 		templateValues.isGlobalMod = results.user.isGlobalMod;
 		templateValues.showModMenu = results.user.isAdmin || results.user.isGlobalMod || results.user.isMod;
-		templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged']) && meta.config.disableChat !== 1;
+		templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged'])
+			&& meta.config.disableChat !== 1;
 		templateValues.user = results.user;
 		templateValues.userJSON = jsesc(JSON.stringify(results.user), { isScriptContext: true });
-		templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS;
-		templateValues.customCSS = templateValues.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '';
-		templateValues.useCustomHTML = meta.config.useCustomHTML;
-		templateValues.customHTML = templateValues.useCustomHTML ? meta.config.customHTML : '';
 		templateValues.maintenanceHeader = meta.config.maintenanceMode && !results.isAdmin;
 		templateValues.defaultLang = meta.config.defaultLang || 'en-GB';
 		templateValues.userLang = res.locals.config.userLang;
 		templateValues.languageDirection = results.languageDirection;
-		if (req.query.noScriptMessage) {
-			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
-		}
-
-		templateValues.template = { name: res.locals.template };
-		templateValues.template[res.locals.template] = true;
-
+		
 		if (options.hasOwnProperty('_header')) {
 			templateValues.metaTags = options._header.tags.meta;
 			templateValues.linkTags = options._header.tags.link;
 		}
-
-		if (req.route && req.route.path === '/') {
-			modifyTitle(templateValues);
-		}
-		return templateValues;
 	}
-
 	async function loadAdminHeaderFooterData(req, res, options) {
 		const custom_header = {
 			plugins: [],

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -231,7 +231,7 @@ module.exports = function (middleware) {
 			navigation: results.navigation,
 			unreadData,
 		}));
-		populateTemplateValues(templateValues, results, req.query, options, res.locals.config);
+		populateTemplateValues(templateValues, results, res.locals.config);
 		if (req.query.noScriptMessage) {
 			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
 		}

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -462,33 +462,30 @@ module.exports = function (middleware) {
 		});
 
 		const { tidsByFilter } = results.unreadData;
-		navigation = navigation.map((item) => {
-			function modifyNavItem(item, route, filter, content) {
-				if (item && item.originalRoute === route) {
-					unreadData[filter] = _.zipObject(tidsByFilter[filter], tidsByFilter[filter].map(() => true));
-					item.content = content;
-					unreadCount.mobileUnread = content;
-					unreadCount.unreadUrl = route;
-					if (unreadCounts[filter] > 0) {
-						item.iconClass += ' unread-count';
-					}
+		function modifyNavItem(item, route, filter, content) {
+			if (item && item.originalRoute === route) {
+				unreadData[filter] = _.zipObject(tidsByFilter[filter], tidsByFilter[filter].map(() => true));
+				item.content = content;
+				unreadCount.mobileUnread = content;
+				unreadCount.unreadUrl = route;
+				if (unreadCounts[filter] > 0) {
+					item.iconClass += ' unread-count';
 				}
 			}
+		}
+		navigation = navigation.map((item) => {
 			modifyNavItem(item, '/unread', '', unreadCount.topic);
 			modifyNavItem(item, '/unread?filter=new', 'new', unreadCount.newTopic);
 			modifyNavItem(item, '/unread?filter=watched', 'watched', unreadCount.watchedTopic);
 			modifyNavItem(item, '/unread?filter=unreplied', 'unreplied', unreadCount.unrepliedTopic);
-
 			['flags'].forEach((prop) => {
 				if (item && item.originalRoute === `/${prop}` && unreadCount[prop] > 0) {
 					item.iconClass += ' unread-count';
 					item.content = unreadCount.flags;
 				}
 			});
-
 			return item;
 		});
-
 		return { navigation, unreadCount };
 	}
 

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -85,7 +85,7 @@ module.exports = function (middleware) {
 				options._locals = undefined;
 
 				if (res.locals.isAPI) {
-					checkAPI(req, options, res)
+					checkAPI(req, options, res);
 				}
 				const optionsString = JSON.stringify(options).replace(/<\//g, '<\\/');
 				const headerFooterData = await loadHeaderFooterData(req, res, options);
@@ -152,7 +152,7 @@ module.exports = function (middleware) {
 		return null;
 	}
 
-	async function initializeTemplate (options){
+	async function initializeTemplate(options, res) {
 		const registrationType = meta.config.registrationType || 'normal';
 		res.locals.config = res.locals.config || {};
 		return {
@@ -173,10 +173,9 @@ module.exports = function (middleware) {
 			bodyClass: options.bodyClass,
 			widgets: options.widgets,
 		};
-
 	}
 	async function loadClientHeaderFooterData(req, res, options) {
-		const templateValues = initializeTemplate(options);
+		const templateValues = initializeTemplate(options, res);
 
 		templateValues.configJSON = jsesc(JSON.stringify(res.locals.config), { isScriptContext: true });
 
@@ -259,7 +258,6 @@ module.exports = function (middleware) {
 		}
 		return templateValues;
 	}
-	
 	async function loadAdminHeaderFooterData(req, res, options) {
 		const custom_header = {
 			plugins: [],

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -85,11 +85,7 @@ module.exports = function (middleware) {
 				options._locals = undefined;
 
 				if (res.locals.isAPI) {
-					if (req.route && req.route.path === '/api/') {
-						options.title = '[[pages:home]]';
-					}
-					req.app.set('json spaces', global.env === 'development' || req.query.pretty ? 4 : 0);
-					return res.json(options);
+					checkAPI(req, options, res)
 				}
 				const optionsString = JSON.stringify(options).replace(/<\//g, '<\\/');
 				const headerFooterData = await loadHeaderFooterData(req, res, options);
@@ -124,6 +120,14 @@ module.exports = function (middleware) {
 
 		next();
 	};
+
+	async function checkAPI(req, options, res) {
+		if (req.route && req.route.path === '/api/') {
+			options.title = '[[pages:home]]';
+		}
+		req.app.set('json spaces', global.env === 'development' || req.query.pretty ? 4 : 0);
+		return res.json(options);
+	}
 
 	async function getLoggedInUser(req) {
 		if (req.user) {

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -151,10 +151,30 @@ module.exports = function (middleware) {
 		}
 		return null;
 	}
-
-	async function initializeTemplate(options, res) {
+	async function loadClientHeaderFooterData(req, res, options) {
 		const registrationType = meta.config.registrationType || 'normal';
 		res.locals.config = res.locals.config || {};
+		const templateValues = initializeTemplateValues(req, res, options, registrationType);
+		const title = translator.unescape(utils.stripHTMLTags(options.title || ''));
+		const results = await utils.promiseParallel({
+			isAdmin: user.isAdministrator(req.uid),
+			isGlobalMod: user.isGlobalModerator(req.uid),
+			isModerator: user.isModeratorOfAnyCategory(req.uid),
+			privileges: privileges.global.get(req.uid),
+			blocks: user.blocks.list(req.uid),
+			user: user.getUserData(req.uid),
+			isEmailConfirmSent: req.uid <= 0 ? false : await user.email.isValidationPending(req.uid),
+			languageDirection: translator.translate('[[language:dir]]', res.locals.config.userLang),
+			timeagoCode: languages.userTimeagoCode(res.locals.config.userLang),
+			browserTitle: translator.translate(controllersHelpers.buildTitle(title)),
+			navigation: navigation.get(req.uid),
+			roomIds: req.uid > 0 ? db.getSortedSetRevRange(`uid:${req.uid}:chat:rooms`, 0, 0) : [],
+		});
+		populateUserDetails(results, req.uid, results.user);
+		populateTemplateValues(templateValues, results, req.query, options, res.locals.config, req, res);
+		return templateValues;
+	}
+	function initializeTemplateValues(req, res, options, registrationType) {
 		return {
 			title: meta.config.title || '',
 			'title:url': meta.config['title:url'] || '',
@@ -167,73 +187,52 @@ module.exports = function (middleware) {
 			allowRegistration: registrationType === 'normal',
 			searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
 			postQueueEnabled: !!meta.config.postQueue,
-			registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' || (meta.config.registrationType === 'invite-only' || meta.config.registrationType === 'admin-invite-only'),
+			registrationQueueEnabled: meta.config.registrationApprovalType !== 'normal' || ['invite-only', 'admin-invite-only'].includes(meta.config.registrationType),
 			config: res.locals.config,
 			relative_path,
 			bodyClass: options.bodyClass,
 			widgets: options.widgets,
+			configJSON: jsesc(JSON.stringify(res.locals.config), { isScriptContext: true }),
+			browserTitle: '',
 		};
 	}
-	async function loadClientHeaderFooterData(req, res, options) {
-		const templateValues = initializeTemplate(options, res);
-		// Perform parallel operations
-		const results = await performParallelOperations(req.uid, res, options);
-		// Process user data
-		processUserData(results, req.uid);
-		// Update template values
-		updateTemplateValues(templateValues, results, req, options, res);
-		return templateValues;
-	}
-	// Helper function to perform parallel operations
-	async function performParallelOperations(uid, res, options) {
-		return await utils.promiseParallel({
-			isAdmin: user.isAdministrator(uid),
-			isGlobalMod: user.isGlobalModerator(uid),
-			isModerator: user.isModeratorOfAnyCategory(uid),
-			privileges: privileges.global.get(uid),
-			blocks: user.blocks.list(uid),
-			user: user.getUserData(uid),
-			isEmailConfirmSent: uid <= 0 ? false : await user.email.isValidationPending(uid),
-			languageDirection: translator.translate('[[language:dir]]', res.locals.config.userLang),
-			timeagoCode: languages.userTimeagoCode(res.locals.config.userLang),
-			browserTitle: translator.translate(controllersHelpers.buildTitle(translator.unescape(utils.stripHTMLTags(options.title || '')))),
-			navigation: navigation.get(uid),
-			roomIds: uid > 0 ? db.getSortedSetRevRange(`uid:${uid}:chat:rooms`, 0, 0) : [],
-		});
-	}
-	// Helper function to process user data
-	function processUserData(results) {
+	function populateUserDetails(results, uid, user) {
 		const unreadData = {
 			'': {},
 			new: {},
 			watched: {},
 			unreplied: {},
 		};
-		results.user = {
-			...results.user,
-			unreadData,
-			isAdmin: results.isAdmin,
-			isGlobalMod: results.isGlobalMod,
-			isMod: !!results.isModerator,
-			privileges: results.privileges,
-			blocks: results.blocks,
-			timeagoCode: results.timeagoCode,
-			[results.user.status]: true,
-			lastRoomId: results.roomIds.length ? results.roomIds[0] : null,
-			email: String(results.user.email),
-			'email:confirmed': results.user['email:confirmed'] === 1,
-			isEmailConfirmSent: !!results.isEmailConfirmSent,
-		};
+		results.user.unreadData = unreadData;
+		results.user.isAdmin = results.isAdmin;
+		results.user.isGlobalMod = results.isGlobalMod;
+		results.user.isMod = !!results.isModerator;
+		results.user.privileges = results.privileges;
+		results.user.blocks = results.blocks;
+		results.user.timeagoCode = results.timeagoCode;
+		results.user[results.user.status] = true;
+		results.user.lastRoomId = results.roomIds.length ? results.roomIds[0] : null;
+		results.user.email = String(user.email);
+		results.user['email:confirmed'] = user['email:confirmed'] === 1;
+		results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
 	}
-	// Helper function to update template values
-	async function updateTemplateValues(templateValues, results, req, options, res) {
-		templateValues.bootswatchSkin = meta.config.bootswatchSkin || '';
+	async function populateTemplateValues(templateValues, results, query, options, config, req, res) {
+		const unreadData = {
+			'': {},
+			new: {},
+			watched: {},
+			unreplied: {},
+		};
+		templateValues.bootswatchSkin = res.locals.config.bootswatchSkin || '';
 		templateValues.browserTitle = results.browserTitle;
-		({ navigation: templateValues.navigation, unreadCount: templateValues.unreadCount } = await appendUnreadCounts({
+		({
+			navigation: templateValues.navigation,
+			unreadCount: templateValues.unreadCount,
+		} = await appendUnreadCounts({
 			uid: req.uid,
 			query: req.query,
 			navigation: results.navigation,
-			unreadData: results.user.unreadData,
+			unreadData,
 		}));
 		templateValues.isAdmin = results.user.isAdmin;
 		templateValues.isGlobalMod = results.user.isGlobalMod;
@@ -241,7 +240,8 @@ module.exports = function (middleware) {
 		templateValues.canChat = (results.privileges.chat || results.privileges['chat:privileged']) && meta.config.disableChat !== 1;
 		templateValues.user = results.user;
 		templateValues.userJSON = jsesc(JSON.stringify(results.user), { isScriptContext: true });
-		templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS ? meta.config.renderedCustomCSS || '' : '';
+		templateValues.useCustomCSS = meta.config.useCustomCSS && meta.config.customCSS;
+		templateValues.customCSS = templateValues.useCustomCSS ? (meta.config.renderedCustomCSS || '') : '';
 		templateValues.useCustomHTML = meta.config.useCustomHTML;
 		templateValues.customHTML = templateValues.useCustomHTML ? meta.config.customHTML : '';
 		templateValues.maintenanceHeader = meta.config.maintenanceMode && !results.isAdmin;
@@ -251,7 +251,8 @@ module.exports = function (middleware) {
 		if (req.query.noScriptMessage) {
 			templateValues.noScriptMessage = validator.escape(String(req.query.noScriptMessage));
 		}
-		templateValues.template = { name: res.locals.template, [res.locals.template]: true };
+		templateValues.template = { name: res.locals.template };
+		templateValues.template[res.locals.template] = true;
 		if (options.hasOwnProperty('_header')) {
 			templateValues.metaTags = options._header.tags.meta;
 			templateValues.linkTags = options._header.tags.link;
@@ -461,41 +462,32 @@ module.exports = function (middleware) {
 		});
 
 		const { tidsByFilter } = results.unreadData;
-		// Helper function to modify navigation items
-		function modifyNavItem(item, route, filter, content, unreadData, unreadCount, unreadCounts) {
-			if (item && item.originalRoute === route) {
-				unreadData[filter] = _.zipObject(tidsByFilter[filter], tidsByFilter[filter].map(() => true));
-				item.content = content;
-				unreadCount.mobileUnread = content;
-				unreadCount.unreadUrl = route;
-				if (unreadCounts[filter] > 0) {
-					item.iconClass += ' unread-count';
+		navigation = navigation.map((item) => {
+			function modifyNavItem(item, route, filter, content) {
+				if (item && item.originalRoute === route) {
+					unreadData[filter] = _.zipObject(tidsByFilter[filter], tidsByFilter[filter].map(() => true));
+					item.content = content;
+					unreadCount.mobileUnread = content;
+					unreadCount.unreadUrl = route;
+					if (unreadCounts[filter] > 0) {
+						item.iconClass += ' unread-count';
+					}
 				}
 			}
-		}
+			modifyNavItem(item, '/unread', '', unreadCount.topic);
+			modifyNavItem(item, '/unread?filter=new', 'new', unreadCount.newTopic);
+			modifyNavItem(item, '/unread?filter=watched', 'watched', unreadCount.watchedTopic);
+			modifyNavItem(item, '/unread?filter=unreplied', 'unreplied', unreadCount.unrepliedTopic);
 
-		// Function to handle flags separately
-		function handleFlags(item, unreadCount) {
 			['flags'].forEach((prop) => {
 				if (item && item.originalRoute === `/${prop}` && unreadCount[prop] > 0) {
 					item.iconClass += ' unread-count';
 					item.content = unreadCount.flags;
 				}
 			});
-		}
 
-		// Refactored map function
-		navigation = navigation.map((item) => {
-			// Apply modifications for different routes and filters
-			modifyNavItem(item, '/unread', '', unreadCount.topic, unreadData, unreadCount, unreadCounts);
-			modifyNavItem(item, '/unread?filter=new', 'new', unreadCount.newTopic, unreadData, unreadCount, unreadCounts);
-			modifyNavItem(item, '/unread?filter=watched', 'watched', unreadCount.watchedTopic, unreadData, unreadCount, unreadCounts);
-			modifyNavItem(item, '/unread?filter=unreplied', 'unreplied', unreadCount.unrepliedTopic, unreadData, unreadCount, unreadCounts);
-			// Handle flags separately
-			handleFlags(item, unreadCount);
 			return item;
 		});
-
 
 		return { navigation, unreadCount };
 	}


### PR DESCRIPTION
resolves #52 

Fixed three errors in the code:
- Cognitive complexity of processRender function from 16 to 15 - by moving out part of the code into a different function
- Cognitive complexity of loadClientHeaderFooterData from 27 to 15 - by moving most of the code into separate functions, and doing early returns
- Deep nesting of the functions - by extracting the deeply nested functions and declaring them outside.  

Changes have been tested by the SonarCloud Quality Gate and by using the lint and test suite provided