### PR TITLE
Refactor NodeBB/src/flags.js to reduce Cognitive Complexity from 16 to 15

### DIFF
--- a/src/flags.js
+++ b/src/flags.js
@@ -189,8 +189,8 @@ async function getFlagIdsFromSets(sets) {
 }
 
 async function getFlagIdsFromOrSets(orSets) {
-	const _flagIds = await Promise.all(orSets.map(async orSet =>
-		await db.getSortedSetRevUnion({ sets: orSet, start: 0, stop: -1, aggregate: 'MAX' })
+	const _flagIds = await Promise.all(orSets.map(async (orSet) =>
+		db.getSortedSetRevUnion({ sets: orSet, start: 0, stop: -1, aggregate: 'MAX' })
 	));
 	return _.intersection(..._flagIds);
 }
@@ -198,10 +198,11 @@ async function getFlagIdsFromOrSets(orSets) {
 function mergeFlagIds(flagIds, _flagIds, hasSets) {
 	if (hasSets) {
 		return _.intersection(flagIds, _flagIds);
-	} else {
-		return _.union(flagIds, _flagIds);
 	}
+	// Since there's no need for 'else' after 'return', simply return the union directly
+	return _.union(flagIds, _flagIds);
 }
+
 
 
 Flags.list = async function (data) {

--- a/src/flags.js
+++ b/src/flags.js
@@ -189,9 +189,7 @@ async function getFlagIdsFromSets(sets) {
 }
 
 async function getFlagIdsFromOrSets(orSets) {
-	const _flagIds = await Promise.all(orSets.map(async (orSet) =>
-		db.getSortedSetRevUnion({ sets: orSet, start: 0, stop: -1, aggregate: 'MAX' })
-	));
+	const _flagIds = await Promise.all(orSets.map(async orSet => db.getSortedSetRevUnion({ sets: orSet, start: 0, stop: -1, aggregate: 'MAX' })));
 	return _.intersection(..._flagIds);
 }
 
@@ -199,7 +197,6 @@ function mergeFlagIds(flagIds, _flagIds, hasSets) {
 	if (hasSets) {
 		return _.intersection(flagIds, _flagIds);
 	}
-	// Since there's no need for 'else' after 'return', simply return the union directly
 	return _.union(flagIds, _flagIds);
 }
 

--- a/src/flags.js
+++ b/src/flags.js
@@ -197,16 +197,16 @@ function combineFlagIds(sets, flagIds, _flagIds) {
     } else {
         return _.union(flagIds, _flagIds);
     }
-}
 
-	const result = await plugins.hooks.fire('filter:flags.getFlagIdsWithFilters', {
-		filters,
-		uid,
-		query,
-		flagIds,
-	});
-	return result.flagIds;
-};
+		const result = await plugins.hooks.fire('filter:flags.getFlagIdsWithFilters', {
+			filters,
+			uid,
+			query,
+			flagIds,
+		});
+		return result.flagIds;
+	};
+}
 
 Flags.list = async function (data) {
 	const filters = data.filters || {};


### PR DESCRIPTION
This pull request refactors the `getFlagIdsWithFilters` function in `flags.js` to address multiple concerns, including reducing Cognitive Complexity and fixing various linting errors. The following changes were made:

1. **Reduced Cognitive Complexity**:
   - **Extracted filter initialization logic** into a new `initializeFilters` function to separate concerns.
   - **Created a `buildSets` function** to encapsulate the logic for constructing `sets` and `orSets`, improving the readability of the main function.
   - **Extracted the logic for fetching flag IDs** based on `sets` into a new `getFlagIdsFromSets` function.
   - **Separated the processing of `orSets`** into two functions: `getFlagIdsFromOrSets` to handle retrieval and `mergeFlagIds` to handle the merging logic, reducing nested conditions and overall complexity.

2. **Fixed Linting Errors**:
   - **Removed unnecessary parentheses** around single arguments in arrow functions (specifically in the `getFlagIdsFromOrSets` function).
   - **Adjusted line breaks** to eliminate unexpected line breaks before expressions and to comply with style rules.
   - **Corrected unexpected newlines** before closing parentheses in function calls, ensuring proper formatting and adherence to style guidelines.
   - **Eliminated an unnecessary `else` statement** after a `return`, as the `else` was redundant and removed to streamline the code.

This pull request resolves Issue #53 
