### PR TITLE
Refactor code in src/groups/update.js

### DIFF
--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -82,31 +82,31 @@ module.exports = function (Groups) {
 			labelColor: values.labelColor || '#000000',
 			textColor: values.textColor || '#ffffff',
 		};
-	
+
 		if (values.hasOwnProperty('userTitle')) {
 			payload.userTitle = values.userTitle || '';
 		}
-	
+
 		if (values.hasOwnProperty('userTitleEnabled')) {
 			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
 		}
-	
+
 		if (values.hasOwnProperty('hidden')) {
 			payload.hidden = values.hidden ? '1' : '0';
 		}
-	
+
 		if (values.hasOwnProperty('private')) {
 			payload.private = values.private ? '1' : '0';
 		}
-	
+
 		if (values.hasOwnProperty('disableJoinRequests')) {
 			payload.disableJoinRequests = values.disableJoinRequests ? '1' : '0';
 		}
-	
+
 		if (values.hasOwnProperty('disableLeave')) {
 			payload.disableLeave = values.disableLeave ? '1' : '0';
 		}
-	
+
 		return payload;
 	}
 

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -16,6 +16,7 @@ module.exports = function (Groups) {
 	Groups.update = async function (groupName, values) {
 		await validateGroupExists(groupName);
 
+		console.log('MOHAMED ELZENI');
 		values = await applyPluginFilters(groupName, values);
 
 		// Cast some values as bool (if not boolean already)

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -22,7 +22,36 @@ module.exports = function (Groups) {
 		// 'true' and '1' = true, everything else false
 		values = castBooleanValues(values);
 
-		const payload = createPayload(values);
+		const payload = {
+			description: values.description || '',
+			icon: values.icon || '',
+			labelColor: values.labelColor || '#000000',
+			textColor: values.textColor || '#ffffff',
+		};
+
+		if (values.hasOwnProperty('userTitle')) {
+			payload.userTitle = values.userTitle || '';
+		}
+
+		if (values.hasOwnProperty('userTitleEnabled')) {
+			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
+		}
+
+		if (values.hasOwnProperty('hidden')) {
+			payload.hidden = values.hidden ? '1' : '0';
+		}
+
+		if (values.hasOwnProperty('private')) {
+			payload.private = values.private ? '1' : '0';
+		}
+
+		if (values.hasOwnProperty('disableJoinRequests')) {
+			payload.disableJoinRequests = values.disableJoinRequests ? '1' : '0';
+		}
+
+		if (values.hasOwnProperty('disableLeave')) {
+			payload.disableLeave = values.disableLeave ? '1' : '0';
+		}
 
 		if (values.hasOwnProperty('name')) {
 			await checkNameChange(groupName, values.name);

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -24,23 +24,7 @@ module.exports = function (Groups) {
 
 		const payload = createPayload(values);
 
-		if (values.hasOwnProperty('name')) {
-			await checkNameChange(groupName, values.name);
-		}
-
-		if (values.hasOwnProperty('private')) {
-			await updatePrivacy(groupName, values.private);
-		}
-
-		if (values.hasOwnProperty('hidden')) {
-			await updateVisibility(groupName, values.hidden);
-		}
-
-		if (values.hasOwnProperty('memberPostCids')) {
-			const validCids = await categories.getCidsByPrivilege('categories:cid', groupName, 'topics:read');
-			const cidsArray = values.memberPostCids.split(',').map(cid => parseInt(cid.trim(), 10)).filter(Boolean);
-			payload.memberPostCids = cidsArray.filter(cid => validCids.includes(cid)).join(',') || '';
-		}
+		await handleSpecialProperties(groupName, values, payload);
 
 		await db.setObject(`group:${groupName}`, payload);
 		await Groups.renameGroup(groupName, values.name);
@@ -108,6 +92,26 @@ module.exports = function (Groups) {
 		}
 
 		return payload;
+	}
+
+	async function handleSpecialProperties(groupName, values, payload) {
+		if (values.hasOwnProperty('name')) {
+			await checkNameChange(groupName, values.name);
+		}
+
+		if (values.hasOwnProperty('private')) {
+			await updatePrivacy(groupName, values.private);
+		}
+
+		if (values.hasOwnProperty('hidden')) {
+			await updateVisibility(groupName, values.hidden);
+		}
+
+		if (values.hasOwnProperty('memberPostCids')) {
+			const validCids = await categories.getCidsByPrivilege('categories:cid', groupName, 'topics:read');
+			const cidsArray = values.memberPostCids.split(',').map(cid => parseInt(cid.trim(), 10)).filter(Boolean);
+			payload.memberPostCids = cidsArray.filter(cid => validCids.includes(cid)).join(',') || '';
+		}
 	}
 
 	async function updateVisibility(groupName, hidden) {

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -22,36 +22,7 @@ module.exports = function (Groups) {
 		// 'true' and '1' = true, everything else false
 		values = castBooleanValues(values);
 
-		const payload = {
-			description: values.description || '',
-			icon: values.icon || '',
-			labelColor: values.labelColor || '#000000',
-			textColor: values.textColor || '#ffffff',
-		};
-
-		if (values.hasOwnProperty('userTitle')) {
-			payload.userTitle = values.userTitle || '';
-		}
-
-		if (values.hasOwnProperty('userTitleEnabled')) {
-			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('hidden')) {
-			payload.hidden = values.hidden ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('private')) {
-			payload.private = values.private ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('disableJoinRequests')) {
-			payload.disableJoinRequests = values.disableJoinRequests ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('disableLeave')) {
-			payload.disableLeave = values.disableLeave ? '1' : '0';
-		}
+		const payload = createPayload(values);
 
 		if (values.hasOwnProperty('name')) {
 			await checkNameChange(groupName, values.name);
@@ -102,6 +73,41 @@ module.exports = function (Groups) {
 			}
 		});
 		return values;
+	}
+
+	function createPayload(values) {
+		const payload = {
+			description: values.description || '',
+			icon: values.icon || '',
+			labelColor: values.labelColor || '#000000',
+			textColor: values.textColor || '#ffffff',
+		};
+	
+		if (values.hasOwnProperty('userTitle')) {
+			payload.userTitle = values.userTitle || '';
+		}
+	
+		if (values.hasOwnProperty('userTitleEnabled')) {
+			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
+		}
+	
+		if (values.hasOwnProperty('hidden')) {
+			payload.hidden = values.hidden ? '1' : '0';
+		}
+	
+		if (values.hasOwnProperty('private')) {
+			payload.private = values.private ? '1' : '0';
+		}
+	
+		if (values.hasOwnProperty('disableJoinRequests')) {
+			payload.disableJoinRequests = values.disableJoinRequests ? '1' : '0';
+		}
+	
+		if (values.hasOwnProperty('disableLeave')) {
+			payload.disableLeave = values.disableLeave ? '1' : '0';
+		}
+	
+		return payload;
 	}
 
 	async function updateVisibility(groupName, hidden) {

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -67,32 +67,27 @@ module.exports = function (Groups) {
 			textColor: values.textColor || '#ffffff',
 		};
 
+		const booleanFields = [
+			'userTitleEnabled',
+			'hidden',
+			'private',
+			'disableJoinRequests',
+			'disableLeave',
+		];
+
+		booleanFields.forEach((field) => {
+			if (values.hasOwnProperty(field)) {
+				payload[field] = values[field] ? '1' : '0';
+			}
+		});
+
 		if (values.hasOwnProperty('userTitle')) {
 			payload.userTitle = values.userTitle || '';
 		}
 
-		if (values.hasOwnProperty('userTitleEnabled')) {
-			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('hidden')) {
-			payload.hidden = values.hidden ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('private')) {
-			payload.private = values.private ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('disableJoinRequests')) {
-			payload.disableJoinRequests = values.disableJoinRequests ? '1' : '0';
-		}
-
-		if (values.hasOwnProperty('disableLeave')) {
-			payload.disableLeave = values.disableLeave ? '1' : '0';
-		}
-
 		return payload;
 	}
+
 
 	async function handleSpecialProperties(groupName, values, payload) {
 		if (values.hasOwnProperty('name')) {


### PR DESCRIPTION
**Issue:** The function `Groups.update` in file [src/groups/update.js](https://github.com/CMU-17313Q/NodeBB/blob/f24/src/groups/update.js) has a complex control flow, causing its Cognitive Complexity on [SonarCloud](https://sonarcloud.io/project/issues?cleanCodeAttributeCategories=ADAPTABLE&fileUuids=AZGVh9RV4m3Xmlma-AuX&issueStatuses=OPEN%2CCONFIRMED&id=CMU-17313Q_NodeBB&open=AZGVh9-o4m3Xmlma-A_y&tab=code) to reach 27, which is higher than the allowed 15. resolves #43

**Fix:** This reduces the Cognitive Complexity of `Groups.update` by refactoring it into smaller, easier-to-manage pieces. This was tested by the linting and testing suite and SonarCloud.